### PR TITLE
Fix a bug in which unspent separators would be too many if a button was clicked too furiously

### DIFF
--- a/script.js
+++ b/script.js
@@ -1434,6 +1434,7 @@ function calculateUnspentSeparators() {
 
 function buySeparatorBoost(x, max=0) {
 	if (x==4) {
+		calculateUnspentSeparators() // make sure it is accurate before we divide.
 		splitSPAmount = game.unspentSeparatorPoints.div(3).floor()
 		for (i=0;i<3;i++) game.separatorBoosts[i] = game.separatorBoosts[i].add(splitSPAmount)
 		calculateUnspentSeparators()


### PR DESCRIPTION
Fix a bug in which unspent separators would be too many if a button was clicked too furiously. If you buy boosters too fast you sometimes get an error in the console log that your index is out of range because the remainder of a div by 3 is somehow larger than 2 because the separators weren't calculated correctly before division. Most users wouldn't notice it as clicking the button again would solve the problem in most cases.